### PR TITLE
Add `quantize`

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -25,6 +25,7 @@
         "src/node-argument.cc",
         "src/loadModel.cc",
         "src/train.cc",
+        "src/quantize.cc",
         "src/classifier.h",
         "src/classifierWorker.cc",
         "src/query.h",

--- a/src/classifier.h
+++ b/src/classifier.h
@@ -9,6 +9,7 @@
 #include "classifierWorker.h"
 #include "loadModel.h"
 #include "train.h"
+#include "quantize.h"
 
 class Classifier : public Nan::ObjectWrap {
     public:
@@ -20,6 +21,7 @@ class Classifier : public Nan::ObjectWrap {
             Nan::SetPrototypeMethod(tpl, "train", train);
             Nan::SetPrototypeMethod(tpl, "predict", predict);
             Nan::SetPrototypeMethod(tpl, "loadModel", loadModel);
+            Nan::SetPrototypeMethod(tpl, "quantize", quantize);
 
             constructor().Reset(Nan::GetFunction(tpl).ToLocalChecked());
             Nan::Set(target, Nan::New("Classifier").ToLocalChecked(),
@@ -66,8 +68,8 @@ class Classifier : public Nan::ObjectWrap {
         	std::string filename = std::string(*modelArg);
         	Classifier* obj = Nan::ObjectWrap::Unwrap<Classifier>( info.Holder() );
 
-            auto worker = new LoadModel(filename, obj->wrapper_);
-            auto resolver = v8::Promise::Resolver::New( info.GetIsolate());
+            const auto worker = new LoadModel(filename, obj->wrapper_);
+            const auto resolver = v8::Promise::Resolver::New( info.GetIsolate());
             worker->SaveToPersistent("key",resolver);
             info.GetReturnValue().Set(resolver->GetPromise());
             Nan::AsyncQueueWorker( worker );
@@ -114,7 +116,7 @@ class Classifier : public Nan::ObjectWrap {
             std::string conf = std::string(*commandConf);
 
 
-            if (command == "skipgram" || command == "cbow" || command == "supervised") {
+            if (command == "cbow" || command == "quantize" || command == "skipgram" ||  command == "supervised") {
 
                 v8::Local<v8::Object> confObj = v8::Local<v8::Object>::Cast( info[1] );
 
@@ -141,18 +143,29 @@ class Classifier : public Nan::ObjectWrap {
 
                 // std::cout << "Args <<<<< Params" << std::endl;
                 // for (std::string& a : args) {
-                //     std::cout << "Args:" << a << std::endl;
+                //     std::cout << a << " " << std::endl;
                 // }
+                // std::cout << std::endl;
 
                 Classifier* obj = Nan::ObjectWrap::Unwrap<Classifier>(info.Holder());
 
-                auto worker = new Train(args, obj->wrapper_);
-                auto resolver = v8::Promise::Resolver::New(info.GetIsolate());
-                worker->SaveToPersistent("key", resolver);
-                info.GetReturnValue().Set(resolver->GetPromise());
-                Nan::AsyncQueueWorker(worker);
+                if (command == "quantize") {
+                    auto worker = new Quantize(args, obj->wrapper_);
+                    auto resolver = v8::Promise::Resolver::New(info.GetIsolate());
+                    worker->SaveToPersistent("key", resolver);
+                    info.GetReturnValue().Set(resolver->GetPromise());
+                    Nan::AsyncQueueWorker(worker);
+                } else {
+                    auto worker = new Train(args, obj->wrapper_);
+                    auto resolver = v8::Promise::Resolver::New(info.GetIsolate());
+                    worker->SaveToPersistent("key", resolver);
+                    info.GetReturnValue().Set(resolver->GetPromise());
+                    Nan::AsyncQueueWorker(worker);
+                }
+
+                
             } else {
-                Nan::ThrowError("Permitted command type is ['skipgram', 'cbow', 'supervised'].");
+                Nan::ThrowError("Permitted types are ['cbow', 'quantize', 'skipgram', 'supervised'].");
                 return;
             }
         }
@@ -163,6 +176,60 @@ class Classifier : public Nan::ObjectWrap {
         }
 
         Wrapper* wrapper_;
+
+   static NAN_METHOD(quantize) {
+
+           if (!info[0]->IsString()) {
+                Nan::ThrowError("type argument must be a string.");
+                return;
+            }
+
+            if (!info[1]->IsObject()) {
+                Nan::ThrowError("options argument must be an object.");
+                return;
+            }
+            
+            const v8::String::Utf8Value commandArg(info[0]->ToString());
+            const v8::String::Utf8Value commandConf(info[1]->ToString());
+            const std::string command = std::string(*commandArg);
+            const std::string conf = std::string(*commandConf);
+
+
+            if (command == "quantize") {
+                const v8::Local<v8::Object> confObj = v8::Local<v8::Object>::Cast( info[1] );
+                
+                NodeArgument::NodeArgument nodeArg;
+                NodeArgument::CArgument c_argument;
+                try {
+                    c_argument = nodeArg.ObjectToCArgument( confObj );
+                } catch (std::string errorMessage) {
+                    Nan::ThrowError(errorMessage.c_str());
+                    return;
+                }
+
+                const int count = c_argument.argc;
+                char** argument = c_argument.argv;
+            
+                std::vector<std::string> args;
+                args.push_back("-command");
+                args.push_back(command.c_str());
+
+                for(int j = 0; j < count; j++) {
+                    args.push_back(argument[j]);
+                }
+
+                const Classifier* obj = Nan::ObjectWrap::Unwrap<Classifier>(info.Holder());
+
+                const auto worker = new Quantize(args, obj->wrapper_);
+                const auto resolver = v8::Promise::Resolver::New(info.GetIsolate());
+                worker->SaveToPersistent("key", resolver);
+                info.GetReturnValue().Set(resolver->GetPromise());
+                Nan::AsyncQueueWorker(worker);
+            } else {
+                Nan::ThrowError("Permitted types are ['quantize'].");
+                return;
+            }
+        }
     };
 
 #endif

--- a/src/node-argument.cc
+++ b/src/node-argument.cc
@@ -112,7 +112,8 @@ namespace NodeArgument
         "input", "test", "output", "lr", "lrUpdateRate", 
         "dim", "ws", "epoch", "minCount", "minCountLabel", "neg",
         "wordNgrams", "loss", "bucket", "minn", "maxn",
-        "thread", "t", "label", "verbose", "pretrainedVectors"
+        "thread", "t", "label", "verbose", "pretrainedVectors",
+        "cutoff", "dsub", "qnorm", "qout", "retrain"
       };
       
       for (uint32_t i = 0; i < indexLen; ++i) {
@@ -131,14 +132,15 @@ namespace NodeArgument
         }
 
         v8::Local<v8::Value> value = obj->Get(v8::String::NewFromUtf8(isolate, theKey));
-        v8::String::Utf8Value utf8_value(value->ToString());
-
-        std::string valueValue = std::string(*utf8_value);
-        char *theValue = (char *)valueValue.c_str();
-
         NodeArgument::AddStringArgument(&arguments, &count, NodeArgument::concat("-", theKey));
-        NodeArgument::AddStringArgument(&arguments, &count, theValue);
 
+        if (!value->IsBoolean())
+        {
+          v8::String::Utf8Value utf8_value(value->ToString());
+          std::string valueValue = std::string(*utf8_value);
+          char *theValue = (char *)valueValue.c_str();
+          NodeArgument::AddStringArgument(&arguments, &count, theValue);
+        }
       }
     }
 

--- a/src/quantize.cc
+++ b/src/quantize.cc
@@ -5,7 +5,7 @@
 void Quantize::Execute () {
 	try {
         result_ = wrapper_->quantize( args_ );
-    } catch (std::string errorMessage) {
+    } catch (const std::string errorMessage) {
         SetErrorMessage(errorMessage.c_str());
     } catch (const char * str) {
         std::cout << "Exception: " << str << std::endl;
@@ -18,14 +18,15 @@ void Quantize::Execute () {
 }
 
 void Quantize::HandleErrorCallback() {
-    Nan::HandleScope scope;
+    const Nan::HandleScope scope;
+
     const auto res = GetFromPersistent("key").As<v8::Promise::Resolver>();
     (void)res->Reject(Nan::GetCurrentContext(), Nan::Error(ErrorMessage()));
     v8::Isolate::GetCurrent()->RunMicrotasks();
 }
 
 void Quantize::HandleOKCallback() {
-    Nan::HandleScope scope;
+    const Nan::HandleScope scope;
 
     NodeArgument::NodeArgument nodeArg;
     const v8::Local<v8::Object> result = nodeArg.mapToObject(result_);

--- a/src/quantize.cc
+++ b/src/quantize.cc
@@ -1,0 +1,35 @@
+#include "node-argument.h"
+#include "quantize.h"
+
+
+void Quantize::Execute () {
+	try {
+        result_ = wrapper_->quantize( args_ );
+    } catch (std::string errorMessage) {
+        SetErrorMessage(errorMessage.c_str());
+    } catch (const char * str) {
+        std::cout << "Exception: " << str << std::endl;
+        SetErrorMessage(str);
+    } catch(const std::exception& e) {
+	    // Handle exception
+        std::cout << "Exception: " << e.what() << std::endl;
+        SetErrorMessage(e.what());
+    }
+}
+
+void Quantize::HandleErrorCallback() {
+    Nan::HandleScope scope;
+    const auto res = GetFromPersistent("key").As<v8::Promise::Resolver>();
+    (void)res->Reject(Nan::GetCurrentContext(), Nan::Error(ErrorMessage()));
+    v8::Isolate::GetCurrent()->RunMicrotasks();
+}
+
+void Quantize::HandleOKCallback() {
+    Nan::HandleScope scope;
+
+    NodeArgument::NodeArgument nodeArg;
+    const v8::Local<v8::Object> result = nodeArg.mapToObject(result_);
+    const auto res = GetFromPersistent("key").As<v8::Promise::Resolver>();
+    (void)res->Resolve(result);
+    v8::Isolate::GetCurrent()->RunMicrotasks();
+}

--- a/src/quantize.h
+++ b/src/quantize.h
@@ -1,0 +1,26 @@
+#ifndef QUANTIZE_H
+#define QUANTIZE_H
+
+#include <nan.h>
+#include "wrapper.h"
+
+class Quantize : public Nan::AsyncWorker {
+  public:
+    Quantize(
+        const std::vector<std::string> args,
+        Wrapper *wrapper
+    ): Nan::AsyncWorker(new Nan::Callback()), args_(args), wrapper_(wrapper), result_(){};
+
+    ~Quantize(){};
+
+    void Execute();
+    void HandleOKCallback();
+    void HandleErrorCallback();
+
+  private:
+    const std::vector<std::string> args_;
+    Wrapper *wrapper_;
+    std::map<std::string, std::string> result_;
+};
+
+#endif

--- a/src/wrapper.cc
+++ b/src/wrapper.cc
@@ -306,8 +306,7 @@ std::map<std::string, std::string> Wrapper::quantize(const std::vector<std::stri
 	std::shared_ptr<Args> a = std::make_shared<Args>();
 	a->parseArgs(args);
 
-	std::string inputFilename = a->input;
-	if ( !fileExist(inputFilename) ) {
+	if ( !fileExist(a->input) ) {
 		throw "Input file is not exist.";
 	}
 
@@ -319,4 +318,5 @@ std::map<std::string, std::string> Wrapper::quantize(const std::vector<std::stri
     fastText_.loadModel(a->output + ".bin");
     fastText_.quantize(a);
     fastText_.saveModel();
+    return loadModel(a->output + ".ftz");
 }

--- a/src/wrapper.cc
+++ b/src/wrapper.cc
@@ -183,6 +183,13 @@ std::map<std::string, std::string> Wrapper::getModelInfo() {
 	response["verbose"] = std::to_string( args_->verbose );
 	response["pretrainedVectors"] = args_->pretrainedVectors;
 
+    // `-quantize` arguments
+    response["cutoff"] = std::to_string(args_->cutoff);
+    response["dsub"] = std::to_string(args_->dsub);
+    response["qnorm"] = std::to_string(args_->qnorm);
+    response["qout"] = std::to_string(args_->qout);
+    response["retrain"] = std::to_string(args_->retrain);
+
 	return response;
 }
 
@@ -295,3 +302,21 @@ std::map<std::string, std::string> Wrapper::train(const std::vector<std::string>
 	return loadModel(a->output + ".bin");
 }
 
+std::map<std::string, std::string> Wrapper::quantize(const std::vector<std::string> args) {
+	std::shared_ptr<Args> a = std::make_shared<Args>();
+	a->parseArgs(args);
+
+	std::string inputFilename = a->input;
+	if ( !fileExist(inputFilename) ) {
+		throw "Input file is not exist.";
+	}
+
+    std::cout << "Input: " << a->input << std::endl;
+    std::cout << "Model: " << a->output + ".bin" << std::endl;
+    std::cout << "Quantized: " << a->output + ".ftz" << std::endl;
+
+    // parseArgs checks if a->output is given.
+    fastText_.loadModel(a->output + ".bin");
+    fastText_.quantize(a);
+    fastText_.saveModel();
+}

--- a/src/wrapper.h
+++ b/src/wrapper.h
@@ -73,6 +73,7 @@ class Wrapper {
         std::vector<PredictResult> predict(std::string sentence, int32_t k);
         std::vector<PredictResult> nn(std::string query, int32_t k);
         std::map<std::string, std::string> train(const std::vector<std::string> args);
+        std::map<std::string, std::string> quantize(const std::vector<std::string> args);
 
 
         void precomputeWordVectors();

--- a/test/specs/trainer.js
+++ b/test/specs/trainer.js
@@ -23,3 +23,24 @@ test('fastText trainer', function (t) {
             t.equal(res.dim, 200, 'dim')
         });
 })
+
+test('fastText quantize', function (t) {
+    t.plan(1)
+    let input = path.resolve(path.join(__dirname, '../data/cooking.train.txt'));
+    let output = path.resolve(path.join(__dirname, '../data/cooking.model'));
+    let classifier = new fastText.Classifier();
+    let options = {
+        input, output,
+        epoch: 1,
+        qnorm: true,
+        qout: true,
+        retrain: true,
+        cutoff: 1000,
+    };
+
+    classifier.train('quantize', options)
+        .then((res) => {console.log(res)})
+        .catch((e) => {console.error(e)});
+    
+    t.ok(true);
+})


### PR DESCRIPTION
Hi, do you plan to add `quantize` to your lib?

I'm working on it but I still have a problem to make it work: https://github.com/vunb/node-fasttext/compare/master...rilut:feature/quantize?expand=1

It seems that my code failed to do something like:

    ./fasttext quantize -output ../test/data/cooking.model -input ../test/data/cooking.train.txt -qnorm -retrain -epoch 1 -cutoff 1000 -qout

Do you have any suggestion on that? Thanks