### PR TITLE
add support for FreeBSD OS, similar to the support for Linux OS

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -51,6 +51,11 @@
               "cflags_c+": [ "-std=c++11", "-fexceptions" ],
               "cflags_cc+": [ "-std=c++11", "-fexceptions" ],
           }],
+          [ "OS=='freebsd'", {
+              "cflags+": [ "-std=c++11", "-fexceptions" ],
+              "cflags_c+": [ "-std=c++11", "-fexceptions" ],
+              "cflags_cc+": [ "-std=c++11", "-fexceptions" ],
+          }],
           [ "OS=='mac'", {
               "cflags+": [ "-stdlib=libc++" ],
               "xcode_settings": {


### PR DESCRIPTION
Please merge the following small change to `binding.gyp` to add support for the FreeBSD operating system, similar to the support for Linux. It is just the same issue: the C++ code needs exceptions and this has to be explicitly enabled. I've tested this with both the system LLVM compiler and an own GCC under FreeBSD. Both worked just fine. Thanks!